### PR TITLE
Set flag to allow BigQuery to return large results

### DIFF
--- a/src/main/scala/com/spotify/spark/bigquery/BigQueryClient.scala
+++ b/src/main/scala/com/spotify/spark/bigquery/BigQueryClient.scala
@@ -179,6 +179,7 @@ private[bigquery] class BigQueryClient(conf: Configuration) {
       .setPriority(PRIORITY)
       .setCreateDisposition("CREATE_IF_NEEDED")
       .setWriteDisposition("WRITE_EMPTY")
+      .setAllowLargeResults(true)
     if (destinationTable != null) {
       queryConfig = queryConfig.setDestinationTable(destinationTable)
     }


### PR DESCRIPTION
With the `AllowLargeResults` flag set, BigQuery can return query results larger
than 128 MB (compressed). Further details are available at:
https://cloud.google.com/bigquery/querying-data#returning_large_query_results
