### PR TITLE
Bump up Spark version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,13 +21,13 @@ scalaVersion := "2.10.6"
 crossScalaVersions := Seq("2.10.6", "2.11.8")
 
 spName := "spotify/spark-bigquery"
-sparkVersion := "1.6.1"
+sparkVersion := "2.0.0"
 sparkComponents := Seq("core", "sql")
 spAppendScalaVersion := true
 spIncludeMaven := true
 
 libraryDependencies ++= Seq(
-  "com.databricks" %% "spark-avro" % "2.0.1",
+  "com.databricks" %% "spark-avro" % "3.0.0",
   "com.google.cloud.bigdataoss" % "bigquery-connector" % "0.7.5-hadoop2"
     exclude ("com.google.guava", "guava-jdk5"),
   "org.slf4j" % "slf4j-simple" % "1.7.21",

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.1.3-SNAPSHOT"
+version in ThisBuild := "0.2.0-SNAPSHOT"


### PR DESCRIPTION
- Bump up Spark to version 2.0.0. There are no actual source changes,
  but since Spark changed DataFrame from a class to a type alias,
  client code (including this project) is binary incompatible with
  Spark 2. Also bump spark-avro.
- Bump up project version to 0.1.4-SNAPSHOT
