### PR TITLE
Only enable "allow large results" when destination table is set

### DIFF
--- a/src/main/scala/com/spotify/spark/bigquery/BigQueryClient.scala
+++ b/src/main/scala/com/spotify/spark/bigquery/BigQueryClient.scala
@@ -179,9 +179,10 @@ private[bigquery] class BigQueryClient(conf: Configuration) {
       .setPriority(PRIORITY)
       .setCreateDisposition("CREATE_IF_NEEDED")
       .setWriteDisposition("WRITE_EMPTY")
-      .setAllowLargeResults(true)
     if (destinationTable != null) {
-      queryConfig = queryConfig.setDestinationTable(destinationTable)
+      queryConfig = queryConfig
+        .setDestinationTable(destinationTable)
+        .setAllowLargeResults(true)
     }
 
     val jobConfig = new JobConfiguration().setQuery(queryConfig).setDryRun(dryRun)


### PR DESCRIPTION
Else the following API error occurs:

```
[error] Exception in thread "main" com.google.api.client.googleapis.json.GoogleJsonResponseException: 400 Bad Request
[error] {
[error]   "code" : 400,
[error]   "errors" : [ {
[error]     "domain" : "global",
[error]     "message" : "allow_large_results requires destination_table.",
[error]     "reason" : "invalid"
[error]   } ],
[error]   "message" : "allow_large_results requires destination_table."
[error] }
```
