### PR TITLE
Partition tables by day

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,7 @@ spIncludeMaven := true
 
 libraryDependencies ++= Seq(
   "com.databricks" %% "spark-avro" % "3.0.0",
-  "com.google.cloud.bigdataoss" % "bigquery-connector" % "0.7.5-hadoop2"
+  "com.google.cloud.bigdataoss" % "bigquery-connector" % "0.8.0-hadoop2"
     exclude ("com.google.guava", "guava-jdk5"),
   "org.slf4j" % "slf4j-simple" % "1.7.21",
   "joda-time" % "joda-time" % "2.9.3",

--- a/src/main/scala/com/spotify/spark/bigquery/BigQueryClient.scala
+++ b/src/main/scala/com/spotify/spark/bigquery/BigQueryClient.scala
@@ -45,6 +45,7 @@ private[bigquery] object BigQueryClient {
   val STAGING_DATASET_LOCATION_DEFAULT = "US"
   val STAGING_DATASET_TABLE_EXPIRATION_MS = 86400000L
   val STAGING_DATASET_DESCRIPTION = "Spark BigQuery staging dataset"
+  val DEFAULT_TABLE_EXPIRATION_MS = 259200000L
 
   private var instance: BigQueryClient = null
 
@@ -121,7 +122,7 @@ private[bigquery] class BigQueryClient(conf: Configuration) {
         table.setTableReference(destinationTable)
         val timePartitioning = new TimePartitioning();
         timePartitioning.setType("DAY");
-        timePartitioning.setExpirationMs(1L);
+        timePartitioning.setExpirationMs(DEFAULT_TABLE_EXPIRATION_MS);
         table.setTimePartitioning(timePartitioning);
         val request = bigquery.tables().insert(projectId, datasetId, table);
         val response = request.execute();

--- a/src/main/scala/com/spotify/spark/bigquery/BigQueryClient.scala
+++ b/src/main/scala/com/spotify/spark/bigquery/BigQueryClient.scala
@@ -115,22 +115,21 @@ private[bigquery] class BigQueryClient(conf: Configuration) {
 
     val tableName = BigQueryStrings.toString(destinationTable)
     if(isPartitionedByDay) {
-        val datasetId = destinationTable.getDatasetId;
-        val projectId: String = destinationTable.getProjectId;
+        val datasetId = destinationTable.getDatasetId
+        val projectId: String = destinationTable.getProjectId
       try {
         logger.info("Creating Time Partitioned Table")
-        val table = new Table();
+        val table = new Table()
         table.setTableReference(destinationTable)
-        val timePartitioning = new TimePartitioning();
-        timePartitioning.setType("DAY");
-        timePartitioning.setExpirationMs(DEFAULT_TABLE_EXPIRATION_MS);
-        table.setTimePartitioning(timePartitioning);
-        val request = bigquery.tables().insert(projectId, datasetId, table);
-        val response = request.execute();
+        val timePartitioning = new TimePartitioning()
+        timePartitioning.setType("DAY")
+        timePartitioning.setExpirationMs(DEFAULT_TABLE_EXPIRATION_MS)
+        table.setTimePartitioning(timePartitioning)
+        val request = bigquery.tables().insert(projectId, datasetId, table)
+        val response = request.execute()
         } catch {
           case e: GoogleJsonResponseException if e.getStatusCode == 409 =>
             logger.info(s"$projectId:$datasetId.$tableName already exists")
-          case NonFatal(e) => throw e
         }
     }
     logger.info(s"Loading $gcsPath into $tableName")

--- a/src/main/scala/com/spotify/spark/bigquery/package.scala
+++ b/src/main/scala/com/spotify/spark/bigquery/package.scala
@@ -152,12 +152,13 @@ package object bigquery {
      */
     def saveAsBigQueryTable(tableRef: TableReference,
                             writeDisposition: WriteDisposition.Value,
-                            createDisposition: CreateDisposition.Value): Unit = {
+                            createDisposition: CreateDisposition.Value,
+                            isPartitionedByDay: Boolean): Unit = {
       val bucket = conf.get(BigQueryConfiguration.GCS_BUCKET_KEY)
       val temp = s"spark-bigquery-${System.currentTimeMillis()}=${Random.nextInt(Int.MaxValue)}"
       val gcsPath = s"gs://$bucket/hadoop/tmp/spark-bigquery/$temp"
       self.write.avro(gcsPath)
-      val df = bq.load(gcsPath, tableRef, writeDisposition, createDisposition)
+      val df = bq.load(gcsPath, tableRef, writeDisposition, createDisposition, isPartitionedByDay)
       delete(new Path(gcsPath))
       df
     }
@@ -167,11 +168,13 @@ package object bigquery {
      */
     def saveAsBigQueryTable(tableSpec: String,
                             writeDisposition: WriteDisposition.Value = null,
-                            createDisposition: CreateDisposition.Value = null): Unit =
+                            createDisposition: CreateDisposition.Value = null,
+                            isPartitionedByDay: Boolean = false): Unit =
       saveAsBigQueryTable(
         BigQueryStrings.parseTableReference(tableSpec),
         writeDisposition,
-        createDisposition)
+        createDisposition,
+        isPartitionedByDay)
 
     private def delete(path: Path): Unit = {
       val fs = FileSystem.get(path.toUri, conf)


### PR DESCRIPTION
This PR was inspired by this [issue](https://github.com/spotify/spark-bigquery/issues/13)

At the moment there is no way of partitioning by day via the job configuration, see [here](http://stackoverflow.com/questions/40665794/table-partitioning-scheme-with-load-job-configuration/40793663#40793663). Google engineers are ofcourse working on it

In the meantime us mortals will have to settle for using the client


