### PR TITLE
Change Spark version from 2.0.2 to 2.2.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,11 +17,11 @@
 
 name := "spark-bigquery"
 organization := "com.spotify"
-scalaVersion := "2.10.6"
+scalaVersion := "2.11.8"
 crossScalaVersions := Seq("2.10.6", "2.11.8")
 
 spName := "spotify/spark-bigquery"
-sparkVersion := "2.0.2"
+sparkVersion := "2.2.0"
 sparkComponents := Seq("core", "sql")
 spAppendScalaVersion := true
 spIncludeMaven := true


### PR DESCRIPTION
We would like to change using spark version from 2.0.2 to 2.2.0. As well as, changing the Scala version from 2.10.6 to 2.11.8 would be good.