### PR TITLE
Enable user to specify write options, hinting about issues with nested records

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,17 @@ val table = sqlContext.bigQueryTable("bigquery-public-data:samples.shakespeare")
 val df = sqlContext.bigQuerySelect(
   "SELECT word, word_count FROM [bigquery-public-data:samples.shakespeare]")
 
-  // Save data to a table
+// Save data to a table
 df.saveAsBigQueryTable("my-project:my_dataset.my_table")
 ```
 
+If you'd like to write nested records to BigQuery, be sure to specify an Avro Namespace.
+BigQuery is unable to load Avro Namespaces with a leading dot (`.nestedColumn`) on nested records.
+
+```scala
+// BigQuery is able to load fields with namespace 'myNamespace.nestedColumn'
+df.saveAsBigQueryTable("my-project:my_dataset.my_table", tmpWriteOptions = Map("recordNamespace" -> "myNamespace"))
+```
 # License
 
 Copyright 2016 Spotify AB.

--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ BigQuery is unable to load Avro Namespaces with a leading dot (`.nestedColumn`) 
 // BigQuery is able to load fields with namespace 'myNamespace.nestedColumn'
 df.saveAsBigQueryTable("my-project:my_dataset.my_table", tmpWriteOptions = Map("recordNamespace" -> "myNamespace"))
 ```
+See also
+[Loading Avro Data from Google Cloud Storage](https://cloud.google.com/bigquery/docs/loading-data-cloud-storage-avro)
+for data type mappings and limitations. For example loading arrays of arrays is not supported.
+
 # License
 
 Copyright 2016 Spotify AB.


### PR DESCRIPTION
Writing nested records to BigQuery with the current implementation was not possible: BigQuery is seemingly unable to load Avro Namespaces with a leading dot (`.nestedColumn`) on nested records.

spark-bigquery utilizes temporary Avro files written to Cloud Storage.
This PR enables users to specify write options such as setting the Avro Namespace which will enable users to write nested records to BigQuery.

Additionally, this PR adds a hint and link to how BigQuery handles the import of Avro files (for example, arrays of arrays are not supported).