### PR TITLE
Make a defensive copy to stop polution of sparkconf

### DIFF
--- a/src/main/scala/com/spotify/spark/bigquery/BigQuerySQLContext.scala
+++ b/src/main/scala/com/spotify/spark/bigquery/BigQuerySQLContext.scala
@@ -37,8 +37,8 @@ import org.apache.spark.sql.{DataFrame, Row, SQLContext}
 class BigQuerySQLContext(sqlContext: SQLContext) {
 
   val sc: SparkContext = sqlContext.sparkContext
-  val conf: Configuration = sc.hadoopConfiguration
-  lazy val bq: BigQueryClient  = BigQueryClient.getInstance(conf)
+  val conf: Configuration = new Configuration(sc.hadoopConfiguration)
+  lazy val bq: BigQueryClient = BigQueryClient.getInstance(conf)
 
   // Register GCS implementation
   if (conf.get("fs.gs.impl") == null) {
@@ -115,11 +115,9 @@ class BigQuerySQLContext(sqlContext: SQLContext) {
     BigQueryConfiguration.configureBigQueryInput(
       conf, tableRef.getProjectId, tableRef.getDatasetId, tableRef.getTableId)
 
-    val fClass = classOf[AvroBigQueryInputFormat]
-    val kClass = classOf[LongWritable]
-    val vClass = classOf[GenericData.Record]
     val rdd = sc
-      .newAPIHadoopRDD(conf, fClass, kClass, vClass)
+      .newAPIHadoopRDD(conf, classOf[AvroBigQueryInputFormat], classOf[LongWritable],
+        classOf[GenericData.Record])
       .map(_._2)
     val schemaString = rdd.map(_.getSchema.toString).first()
     val schema = new Schema.Parser().parse(schemaString)


### PR DESCRIPTION
The code in this project as well of the code inside the underlying input format make direct changes to the hadoop configuration. Unfortunately this causes problems for processes that have to do work in "on-premise" hdfs clusters after doing work with the "off premise" google clusters part. Essentially without this copy things are set in the sparkConfiguration that need to be unset and it is not always easy to unset them.