### PR TITLE
Create daily partitioned table when necessary

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,7 @@ spIncludeMaven := true
 
 libraryDependencies ++= Seq(
   "com.databricks" %% "spark-avro" % "4.0.0",
-  "com.google.cloud.bigdataoss" % "bigquery-connector" % "0.10.2-hadoop2"
+  "com.google.cloud.bigdataoss" % "bigquery-connector" % "hadoop2-0.13.13"
     exclude ("com.google.guava", "guava-jdk5"),
   "org.slf4j" % "slf4j-simple" % "1.7.21",
   "joda-time" % "joda-time" % "2.9.3",

--- a/src/main/scala/com/spotify/spark/bigquery/BigQueryClient.scala
+++ b/src/main/scala/com/spotify/spark/bigquery/BigQueryClient.scala
@@ -125,6 +125,10 @@ private[bigquery] class BigQueryClient(conf: Configuration) {
     if (createDisposition != null) {
       loadConfig = loadConfig.setCreateDisposition(createDisposition.toString)
     }
+    if (destinationTable.getTableId.contains("$")) {
+      val timePartitioning = new TimePartitioning().setType("DAY")
+      loadConfig = loadConfig.setTimePartitioning(timePartitioning)
+    }
 
     val jobConfig = new JobConfiguration().setLoad(loadConfig)
     val jobReference = createJobReference(projectId, JOB_ID_PREFIX)


### PR DESCRIPTION
This commit enables the creation of a partitioned table if the table id in table reference consists of the partition decorator (`$yyyyMMdd`).