### PR TITLE
Add conversion of hyphen into underscore before setting STAGING_DATAS…

### DIFF
--- a/src/main/scala/com/spotify/spark/bigquery/BigQueryClient.scala
+++ b/src/main/scala/com/spotify/spark/bigquery/BigQueryClient.scala
@@ -146,7 +146,7 @@ private[bigquery] class BigQueryClient(conf: Configuration) {
   private def stagingDataset(location: String): DatasetReference = {
     // Create staging dataset if it does not already exist
     val prefix = conf.get(STAGING_DATASET_PREFIX, STAGING_DATASET_PREFIX_DEFAULT)
-    conf.setIfUnset(STAGING_DATASET_ID, prefix + location.toLowerCase)
+    conf.setIfUnset(STAGING_DATASET_ID, prefix + location.toLowerCase.replaceAll("-", "_"))
     val datasetId = conf.get(STAGING_DATASET_ID)
     try {
       bigquery.datasets().get(projectId, datasetId).execute()


### PR DESCRIPTION
Hi,

This pull request includes a minor bug fix to correctly create staging dataset.

In `com.spotify.spark.bigquery.BigQueryClient`, currently `STAGING_DATASET_ID` config includes `STAGING_DATASET_LOCATION` string by default, but if the location includes hyphen(e.g. asia-northeast1), then the dataset-id can't satisfy its naming rule[1] and dataset creation fails.
[1]: https://cloud.google.com/bigquery/docs/datasets#dataset-naming

So could you please add the conversion of hyphen into underscore before setting `STAGING_DATASET_ID`?

Thanks
